### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -19,7 +19,7 @@ class action_plugin_colorbox extends DokuWiki_Action_Plugin {
     /**
      * Register its handlers with the DokuWiki's event controller
      */
-    function register(&$controller) {
+    function register(Doku_Event_Handler $controller) {
         $controller->register_hook('TPL_METAHEADER_OUTPUT', 'BEFORE', $this, 'colorbox_hookjs');
     }
 

--- a/syntax.php
+++ b/syntax.php
@@ -44,7 +44,7 @@ class syntax_plugin_colorbox extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
         parse_str($match, $return);   
         return $return;
     }
@@ -56,7 +56,7 @@ class syntax_plugin_colorbox extends DokuWiki_Syntax_Plugin {
  * @author   Tom Cafferty <tcafferty@glocalfocal.com>
  *
  */
-    function render($mode, &$R, $data) {
+    function render($mode, Doku_Renderer $R, $data) {
       global $conf;
 
       // store meta info for this page


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
